### PR TITLE
Add dataPayload and accessMethod to DatasetItem

### DIFF
--- a/specification/schema/DatasetItem/v1/attributes.yaml
+++ b/specification/schema/DatasetItem/v1/attributes.yaml
@@ -104,6 +104,43 @@ components:
         "dataset:latestRawDataAt":
           type: string
           format: date-time
+        "dataset:accessMethod":
+          type: string
+          description: >
+            How the dataset is delivered to the consumer.
+            INLINE — data embedded in the beckn message via dataPayload.
+            DOWNLOAD — consumer fetches from a URL in schema:distribution.
+            DATA_ENCLAVE — consumer accesses data within a secure enclave environment.
+            OFF_CHANNEL — delivery arranged outside the beckn network.
+          enum:
+            - INLINE
+            - DOWNLOAD
+            - DATA_ENCLAVE
+            - OFF_CHANNEL
+        "dataset:dataPayload":
+          description: >
+            Optional inline data payload. When present, carries the actual dataset
+            content within the beckn message. The @context URI must resolve to a
+            valid schema that describes the payload structure. Used when
+            dataset:accessMethod is INLINE.
+          type: object
+          required:
+            - "@context"
+            - "@type"
+          additionalProperties: true
+          properties:
+            "@context":
+              description: JSON-LD context URI resolving to the payload's schema.
+              oneOf:
+                - type: string
+                  format: uri
+                - type: array
+                  items:
+                    type: string
+                    format: uri
+            "@type":
+              description: The type of data payload (e.g., MeterData, BillingSummary, UtilityCustomerCredential).
+              type: string
         "dataset:qualityFlags":
           type: object
           additionalProperties: true

--- a/specification/schema/DatasetItem/v1/context.jsonld
+++ b/specification/schema/DatasetItem/v1/context.jsonld
@@ -20,6 +20,12 @@
     "uptime99DayPercent": "dataset:uptime99DayPercent",
     "validationMethod": "dataset:validationMethod",
 
+    "accessMethod": "dataset:accessMethod",
+    "dataPayload": {
+      "@id": "dataset:dataPayload",
+      "@type": "@id"
+    },
+
     "verticalRange": "dataset:verticalRange",
     "dataType": "dataset:dataType",
     "rawUpdateFrequency": "dataset:rawUpdateFrequency",

--- a/specification/schema/DatasetItem/v1/vocab.jsonld
+++ b/specification/schema/DatasetItem/v1/vocab.jsonld
@@ -90,6 +90,18 @@
       "rdfs:comment": "Standard or algorithm used for dataset validation."
     },
     {
+      "@id": "dataset:accessMethod",
+      "@type": "rdf:Property",
+      "rdfs:label": "accessMethod",
+      "rdfs:comment": "How the dataset is delivered: INLINE (in-message via dataPayload), DOWNLOAD (fetch from URL), DATA_ENCLAVE (secure enclave access), or OFF_CHANNEL (arranged outside beckn)."
+    },
+    {
+      "@id": "dataset:dataPayload",
+      "@type": "rdf:Property",
+      "rdfs:label": "dataPayload",
+      "rdfs:comment": "Optional inline data payload carrying actual dataset content within the beckn message. A self-describing JSON-LD object whose @context resolves to the payload schema."
+    },
+    {
       "@id": "dataset:verticalRange",
       "@type": "rdf:Property",
       "rdfs:label": "verticalRange",


### PR DESCRIPTION
## Summary
- Adds `dataset:accessMethod` enum (`INLINE`, `DOWNLOAD`, `DATA_ENCLAVE`, `OFF_CHANNEL`) to describe how a dataset is delivered to the consumer
- Adds `dataset:dataPayload` as an optional inline data delivery object with required `@context` and `@type` for self-describing JSON-LD payloads
- Updates `context.jsonld` and `vocab.jsonld` with new property definitions

These additions allow any `DatasetItem` (energy, weather, etc.) to carry inline data payloads and declare their access method generically, removing the need for domain-specific subclasses like `EnergyDataSetItem`.

## Related
- beckn/DEG branch `deg-221-EnergyDataSets-and-Devkit` will be updated to remove `EnergyDataSetItem` and reference `DatasetItem` directly once this merges.

## Test plan
- [x] Validate `attributes.yaml` is valid OpenAPI 3.1.0
- [x] Verify `context.jsonld` resolves new properties correctly
- [x] Verify `vocab.jsonld` defines new RDF properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)