### PR TITLE
feat: add streaming transport access methods (MQTT, Kafka, API, Data Lake)

### DIFF
--- a/specification/schema/DatasetFulfillment/v1.1/README.md
+++ b/specification/schema/DatasetFulfillment/v1.1/README.md
@@ -1,0 +1,190 @@
+# DatasetFulfillment — v1.1
+
+Extends [v1](../v1/attributes.yaml) with `fulfillment:streamConnection` — a credential delivery object for streaming transport access methods (MQTT, Kafka, REST API, cloud data lake). Fully backward-compatible — all v1 fields remain.
+
+## What's new in v1.1
+
+### Relaxed `required`
+
+Only `fulfillment:accessMethod` is required. `accessUrl`, `accessStart`, and `accessEnd` are still present for `DOWNLOAD` but are no longer required fields — streaming methods use `fulfillment:credentialExpiresAt` instead.
+
+### Extended `fulfillment:accessMethod` enum
+
+Aligned with `DatasetItem/v1.1` to include: `DOWNLOAD`, `API`, `STREAM`, `MQTT`, `KAFKA`, `DATA_LAKE`, `DATA_ROOM`, `SFTP`.
+
+### New `fulfillment:streamConnection`
+
+A polymorphic credential object delivered in `performance[].performanceAttributes` of `on_confirm`. The `@type` field discriminates the shape.
+
+```json
+"fulfillment:streamConnection": {
+  "@type": "MQTTConnection | KafkaConsumerCredentials | ApiCredential | DataLakeCredential",
+  "fulfillment:credentialExpiresAt": "<ISO 8601 datetime>",
+  ...transport-specific fields...
+}
+```
+
+**Security note:** All credentials in `streamConnection` MUST be short-lived. The BPP sets `fulfillment:credentialExpiresAt` and the buyer calls `update` before that timestamp to rotate credentials. Beckn messages are signed but not encrypted — treat credentials as you would an API key in a signed webhook.
+
+---
+
+## Credential shapes
+
+### `MQTTConnection`
+
+For `fulfillment:accessMethod: MQTT`. The buyer connects directly to the BPP-operated broker using these credentials.
+
+```json
+"fulfillment:streamConnection": {
+  "@type": "MQTTConnection",
+  "fulfillment:brokerUri": "mqtts://iotcore.example.com:8883",
+  "fulfillment:topic": "energy/meters/zone-a/#",
+  "fulfillment:qos": 1,
+  "fulfillment:clientId": "buyer-org-001-sub",
+  "fulfillment:username": "buyer-org-001",
+  "fulfillment:password": "<short-lived JWT>",
+  "fulfillment:tlsCaCert": "-----BEGIN CERTIFICATE-----\n...",
+  "fulfillment:sessionExpiry": "PT24H",
+  "fulfillment:credentialExpiresAt": "2026-06-07T09:00:00Z"
+}
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `fulfillment:brokerUri` | yes | MQTT broker URI, e.g. `mqtts://` for TLS |
+| `fulfillment:topic` | yes | Topic filter with wildcards, e.g. `energy/meters/zone-a/#` |
+| `fulfillment:qos` | yes | QoS level: 0, 1, or 2 |
+| `fulfillment:clientId` | yes | Broker-provisioned client ID for this buyer |
+| `fulfillment:username` | yes | Short-lived username or JWT subject |
+| `fulfillment:password` | yes | Short-lived password or JWT token |
+| `fulfillment:tlsCaCert` | recommended | PEM CA certificate for `mqtts://` |
+| `fulfillment:sessionExpiry` | recommended | MQTT 5.0 Session Expiry Interval (ISO 8601 duration) |
+| `fulfillment:credentialExpiresAt` | yes | Rotate before this timestamp via `update` |
+
+---
+
+### `KafkaConsumerCredentials`
+
+For `fulfillment:accessMethod: KAFKA`. The buyer configures a Kafka consumer with these properties.
+
+```json
+"fulfillment:streamConnection": {
+  "@type": "KafkaConsumerCredentials",
+  "fulfillment:bootstrapServers": "pkc-xyz.ap-south1.gcp.confluent.cloud:9092",
+  "fulfillment:topicName": "deg.grid-events.india.v1",
+  "fulfillment:consumerGroupId": "buyer-org-001-cg",
+  "fulfillment:saslMechanism": "PLAIN",
+  "fulfillment:saslUsername": "<API_KEY>",
+  "fulfillment:saslPassword": "<API_SECRET>",
+  "fulfillment:schemaRegistryUrl": "https://psrc-xyz.ap-south1.gcp.confluent.cloud",
+  "fulfillment:schemaRegistryUsername": "<SR_KEY>",
+  "fulfillment:schemaRegistryPassword": "<SR_SECRET>",
+  "fulfillment:startOffset": "latest",
+  "fulfillment:credentialExpiresAt": "2026-06-07T09:00:00Z"
+}
+```
+
+Map directly to standard Kafka client properties:
+
+| `fulfillment:` field | Kafka property |
+|---|---|
+| `bootstrapServers` | `bootstrap.servers` |
+| `saslMechanism` | `sasl.mechanism` |
+| `saslUsername` | `sasl.username` / API key |
+| `saslPassword` | `sasl.password` / API secret |
+| `schemaRegistryUrl` | `schema.registry.url` |
+| `consumerGroupId` | `group.id` |
+
+Security protocol is always `SASL_SSL` when `saslMechanism` is present.
+
+---
+
+### `ApiCredential`
+
+For `fulfillment:accessMethod: API`. The buyer calls the REST API using the provisioned token and can explore endpoints via `apiDocUrl`.
+
+```json
+"fulfillment:streamConnection": {
+  "@type": "ApiCredential",
+  "fulfillment:apiEndpoint": "https://api.example.com/v1",
+  "fulfillment:apiDocUrl": "https://api.example.com/v1/openapi.yaml",
+  "fulfillment:authScheme": "BEARER",
+  "fulfillment:bearerToken": "<short-lived JWT>",
+  "fulfillment:rateLimitRpm": 60,
+  "fulfillment:credentialExpiresAt": "2026-06-07T09:00:00Z"
+}
+```
+
+| `fulfillment:authScheme` | Credential field used |
+|---|---|
+| `BEARER` | `fulfillment:bearerToken` |
+| `API_KEY` | `fulfillment:apiKey` (sent as `X-Api-Key` header) |
+| `BASIC` | `fulfillment:username` + `fulfillment:password` |
+| `OAUTH2_CLIENT_CREDENTIALS` | `fulfillment:apiKey` (client ID) + `fulfillment:apiKey` (client secret) — use a pair |
+
+---
+
+### `DataLakeCredential`
+
+For `fulfillment:accessMethod: DATA_LAKE`. Two sub-types via `fulfillment:accessType`:
+
+**PRESIGNED_URL** — static dataset, single signed GET URL:
+
+```json
+"fulfillment:streamConnection": {
+  "@type": "DataLakeCredential",
+  "fulfillment:cloudProvider": "AWS_S3",
+  "fulfillment:accessType": "PRESIGNED_URL",
+  "fulfillment:presignedUrl": "https://bucket.s3.region.amazonaws.com/path?X-Amz-Signature=...",
+  "fulfillment:credentialExpiresAt": "2026-05-08T09:00:00Z"
+}
+```
+
+**STS_CREDENTIALS** — live-append dataset, temporary IAM credentials:
+
+```json
+"fulfillment:streamConnection": {
+  "@type": "DataLakeCredential",
+  "fulfillment:cloudProvider": "AWS_S3",
+  "fulfillment:accessType": "STS_CREDENTIALS",
+  "fulfillment:accessKeyId": "ASIA...",
+  "fulfillment:secretAccessKey": "...",
+  "fulfillment:sessionToken": "...",
+  "fulfillment:bucket": "deg-ami-live-ap-south-1",
+  "fulfillment:storagePrefix": "buyer-org-001/blr-zone-a/",
+  "fulfillment:storageRegion": "ap-south-1",
+  "fulfillment:fileFormat": "Parquet",
+  "fulfillment:partitionPattern": "year={yyyy}/month={MM}/day={dd}/",
+  "fulfillment:credentialExpiresAt": "2026-05-07T21:00:00Z"
+}
+```
+
+**SAS_TOKEN** — Azure ADLS:
+
+```json
+"fulfillment:streamConnection": {
+  "@type": "DataLakeCredential",
+  "fulfillment:cloudProvider": "AZURE_ADLS",
+  "fulfillment:accessType": "SAS_TOKEN",
+  "fulfillment:sasToken": "sv=2022-11-02&ss=b&srt=sco&sp=rl&...",
+  "fulfillment:storagePrefix": "https://account.dfs.core.windows.net/container/buyer-org-001/",
+  "fulfillment:credentialExpiresAt": "2026-05-14T09:00:00Z"
+}
+```
+
+---
+
+## Credential rotation via `update`
+
+For all streaming methods, the BPP sets `fulfillment:credentialExpiresAt`. Before that timestamp the buyer sends an `update` action; the BPP responds with a fresh `on_update` containing a new `fulfillment:streamConnection` with updated credentials. The buyer swaps credentials without interrupting the stream.
+
+```
+update    →  { reason: "credential_renewal" }
+on_update ←  new fulfillment:streamConnection with updated credentials
+```
+
+## Context URL
+
+```
+https://raw.githubusercontent.com/beckn/DDM/main/specification/schema/DatasetFulfillment/v1.1/context.jsonld
+```

--- a/specification/schema/DatasetFulfillment/v1.1/attributes.yaml
+++ b/specification/schema/DatasetFulfillment/v1.1/attributes.yaml
@@ -1,0 +1,248 @@
+openapi: 3.1.0
+info:
+  title: DatasetFulfillment
+  version: 1.1.0
+  description: >
+    Access provisioning details for a fulfilled dataset order.
+    v1.1 adds fulfillment:streamConnection for streaming transport credentials
+    (MQTT, Kafka, REST API, cloud data lake) and relaxes required fields so
+    that accessUrl/accessStart/accessEnd are only needed for DOWNLOAD.
+    Fully backward-compatible with v1.0.
+paths: {}
+components:
+  schemas:
+    DatasetFulfillment:
+      type: object
+      description: Attributes for digital dataset fulfillment attached via beckn:deliveryAttributes.
+      additionalProperties: true
+      required:
+        - "fulfillment:accessMethod"
+      properties:
+        "@context":
+          type: string
+          format: uri
+        "@type":
+          type: string
+        "fulfillment:accessMethod":
+          type: string
+          description: >
+            Access method code indicating how the buyer receives the data.
+            DOWNLOAD — time-limited URL fetch (fulfillment:accessUrl required).
+            API — REST API access; credentials in fulfillment:streamConnection.
+            STREAM — generic real-time stream (use MQTT or KAFKA for specificity).
+            MQTT — MQTT 5.0 push; credentials in fulfillment:streamConnection.
+            KAFKA — Apache Kafka consumer; credentials in fulfillment:streamConnection.
+            DATA_LAKE — cloud object storage; credentials in fulfillment:streamConnection.
+            DATA_ROOM — secure data room access.
+            SFTP — SFTP server access.
+          enum:
+            - DOWNLOAD
+            - API
+            - STREAM
+            - MQTT
+            - KAFKA
+            - DATA_LAKE
+            - DATA_ROOM
+            - SFTP
+        "fulfillment:accessUrl":
+          type: string
+          format: uri
+          description: >
+            Signed or time-limited URL for accessing the dataset.
+            Required when fulfillment:accessMethod is DOWNLOAD.
+        "fulfillment:accessStart":
+          type: string
+          format: date-time
+          description: Start of the access window (ISO 8601 date-time).
+        "fulfillment:accessEnd":
+          type: string
+          format: date-time
+          description: >
+            End of the access window (ISO 8601 date-time).
+            For streaming methods, use fulfillment:streamConnection.fulfillment:credentialExpiresAt instead.
+        "fulfillment:format":
+          type: string
+          description: File or message format (e.g. Parquet, CSV, JSON, Avro, NDJSON).
+        "fulfillment:fileSizeBytes":
+          type: integer
+          description: Approximate size of the delivered file in bytes (DOWNLOAD only).
+        "fulfillment:maxDownloads":
+          type: integer
+          description: Maximum number of times the dataset can be downloaded (DOWNLOAD only).
+        "fulfillment:downloadsUsed":
+          type: integer
+          description: Number of downloads already used by the buyer (DOWNLOAD only).
+        "fulfillment:supportEmail":
+          type: string
+          format: email
+        "fulfillment:termsUrl":
+          type: string
+          format: uri
+        "fulfillment:attributionText":
+          type: string
+        "fulfillment:streamConnection":
+          type: object
+          description: >
+            Stream connection credentials provisioned for the buyer after confirm.
+            Required when fulfillment:accessMethod is MQTT, KAFKA, API, or DATA_LAKE.
+            All credentials MUST be short-lived; set fulfillment:credentialExpiresAt
+            and instruct the buyer to call update before expiry for rotation.
+            The @type discriminator determines which credential fields apply.
+          additionalProperties: true
+          properties:
+            "@type":
+              type: string
+              description: Credential shape discriminator.
+              enum:
+                - MQTTConnection
+                - KafkaConsumerCredentials
+                - ApiCredential
+                - DataLakeCredential
+
+            "fulfillment:credentialExpiresAt":
+              type: string
+              format: date-time
+              description: >
+                When these credentials expire. The buyer must call update before
+                this timestamp to rotate credentials and maintain stream access.
+
+            # ── MQTT fields ────────────────────────────────────────────────
+            "fulfillment:brokerUri":
+              type: string
+              description: >
+                MQTT broker URI (e.g. mqtts://iotcore.example.com:8883).
+                Required for MQTTConnection.
+            "fulfillment:topic":
+              type: string
+              description: >
+                MQTT topic filter the buyer should subscribe to
+                (e.g. energy/meters/zone-a/#). Required for MQTTConnection.
+            "fulfillment:qos":
+              type: integer
+              description: MQTT Quality of Service level agreed for this subscription.
+              enum: [0, 1, 2]
+            "fulfillment:clientId":
+              type: string
+              description: MQTT client ID the broker has provisioned for this buyer.
+            "fulfillment:username":
+              type: string
+              description: MQTT username (short-lived; rotate via update before credentialExpiresAt).
+            "fulfillment:password":
+              type: string
+              description: MQTT password or JWT token (short-lived).
+            "fulfillment:tlsCaCert":
+              type: string
+              description: PEM-encoded CA certificate for TLS verification (mqtts:// connections).
+            "fulfillment:sessionExpiry":
+              type: string
+              description: >
+                MQTT 5.0 Session Expiry Interval as ISO 8601 duration (e.g. PT24H).
+                After this the broker will discard the session if the client disconnects.
+
+            # ── Kafka fields ───────────────────────────────────────────────
+            "fulfillment:bootstrapServers":
+              type: string
+              description: >
+                Comma-separated Kafka bootstrap server list
+                (e.g. pkc-xyz.ap-south1.gcp.confluent.cloud:9092).
+                Required for KafkaConsumerCredentials.
+            "fulfillment:topicName":
+              type: string
+              description: Kafka topic to consume (Required for KafkaConsumerCredentials).
+            "fulfillment:consumerGroupId":
+              type: string
+              description: Kafka consumer group ID provisioned for this buyer.
+            "fulfillment:saslMechanism":
+              type: string
+              description: SASL authentication mechanism.
+              enum: [PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER]
+            "fulfillment:saslUsername":
+              type: string
+              description: Kafka SASL username / API key (short-lived).
+            "fulfillment:saslPassword":
+              type: string
+              description: Kafka SASL password / API secret (short-lived).
+            "fulfillment:schemaRegistryUrl":
+              type: string
+              format: uri
+              description: Schema Registry URL for Avro/Protobuf deserialization.
+            "fulfillment:schemaRegistryUsername":
+              type: string
+            "fulfillment:schemaRegistryPassword":
+              type: string
+            "fulfillment:startOffset":
+              type: string
+              description: Where to begin consuming (latest or earliest).
+              enum: [latest, earliest]
+
+            # ── API fields ─────────────────────────────────────────────────
+            "fulfillment:apiEndpoint":
+              type: string
+              format: uri
+              description: Base URL of the REST API (Required for ApiCredential).
+            "fulfillment:apiDocUrl":
+              type: string
+              format: uri
+              description: >
+                URL to the OpenAPI / Swagger specification for this API.
+                Consumers use this to auto-generate clients or explore endpoints.
+            "fulfillment:authScheme":
+              type: string
+              description: Authentication scheme for the API.
+              enum: [BEARER, API_KEY, BASIC, OAUTH2_CLIENT_CREDENTIALS]
+            "fulfillment:bearerToken":
+              type: string
+              description: Short-lived bearer token (JWT). Rotate via update before credentialExpiresAt.
+            "fulfillment:apiKey":
+              type: string
+              description: API key (short-lived). Rotate via update before credentialExpiresAt.
+            "fulfillment:rateLimitRpm":
+              type: integer
+              description: Requests per minute the buyer is allowed under this contract.
+
+            # ── Data Lake fields ───────────────────────────────────────────
+            "fulfillment:cloudProvider":
+              type: string
+              description: Cloud object storage provider.
+              enum: [AWS_S3, GCS, AZURE_ADLS]
+            "fulfillment:accessType":
+              type: string
+              description: >
+                Credential type for object storage access.
+                PRESIGNED_URL — single signed URL (static dataset, short TTL).
+                STS_CREDENTIALS — temporary IAM role credentials (live/append datasets).
+                SAS_TOKEN — Azure Shared Access Signature (ADLS).
+              enum: [PRESIGNED_URL, STS_CREDENTIALS, SAS_TOKEN]
+            "fulfillment:bucket":
+              type: string
+              description: S3 bucket name or GCS bucket name.
+            "fulfillment:storagePrefix":
+              type: string
+              description: Object key prefix scoped to this buyer's data partition.
+            "fulfillment:presignedUrl":
+              type: string
+              format: uri
+              description: Pre-signed GET URL (PRESIGNED_URL access type only).
+            "fulfillment:accessKeyId":
+              type: string
+              description: AWS temporary access key ID (STS_CREDENTIALS only).
+            "fulfillment:secretAccessKey":
+              type: string
+              description: AWS temporary secret access key (STS_CREDENTIALS only).
+            "fulfillment:sessionToken":
+              type: string
+              description: AWS STS session token (STS_CREDENTIALS only).
+            "fulfillment:sasToken":
+              type: string
+              description: Azure SAS token appended to the blob/container URL (SAS_TOKEN only).
+            "fulfillment:storageRegion":
+              type: string
+              description: Cloud region where the storage bucket is hosted.
+            "fulfillment:fileFormat":
+              type: string
+              description: Format of files in the storage path (e.g. NDJSON, Parquet, CSV).
+            "fulfillment:partitionPattern":
+              type: string
+              description: >
+                Partition path pattern for live-append datasets
+                (e.g. year={yyyy}/month={MM}/day={dd}/).

--- a/specification/schema/DatasetFulfillment/v1.1/context.jsonld
+++ b/specification/schema/DatasetFulfillment/v1.1/context.jsonld
@@ -1,0 +1,64 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "schema": "https://schema.org/",
+    "fulfillment": "./vocab.jsonld#",
+
+    "DatasetFulfillment": "fulfillment:DatasetFulfillment",
+
+    "fulfillment:accessMethod": "fulfillment:accessMethod",
+    "fulfillment:accessUrl": "fulfillment:accessUrl",
+    "fulfillment:accessStart": "fulfillment:accessStart",
+    "fulfillment:accessEnd": "fulfillment:accessEnd",
+    "fulfillment:format": "fulfillment:format",
+    "fulfillment:fileSizeBytes": "fulfillment:fileSizeBytes",
+    "fulfillment:maxDownloads": "fulfillment:maxDownloads",
+    "fulfillment:downloadsUsed": "fulfillment:downloadsUsed",
+    "fulfillment:supportEmail": "fulfillment:supportEmail",
+    "fulfillment:termsUrl": "fulfillment:termsUrl",
+    "fulfillment:attributionText": "fulfillment:attributionText",
+
+    "fulfillment:streamConnection": "fulfillment:streamConnection",
+    "fulfillment:credentialExpiresAt": "fulfillment:credentialExpiresAt",
+
+    "fulfillment:brokerUri": "fulfillment:brokerUri",
+    "fulfillment:topic": "fulfillment:topic",
+    "fulfillment:qos": "fulfillment:qos",
+    "fulfillment:clientId": "fulfillment:clientId",
+    "fulfillment:username": "fulfillment:username",
+    "fulfillment:password": "fulfillment:password",
+    "fulfillment:tlsCaCert": "fulfillment:tlsCaCert",
+    "fulfillment:sessionExpiry": "fulfillment:sessionExpiry",
+
+    "fulfillment:bootstrapServers": "fulfillment:bootstrapServers",
+    "fulfillment:topicName": "fulfillment:topicName",
+    "fulfillment:consumerGroupId": "fulfillment:consumerGroupId",
+    "fulfillment:saslMechanism": "fulfillment:saslMechanism",
+    "fulfillment:saslUsername": "fulfillment:saslUsername",
+    "fulfillment:saslPassword": "fulfillment:saslPassword",
+    "fulfillment:schemaRegistryUrl": "fulfillment:schemaRegistryUrl",
+    "fulfillment:schemaRegistryUsername": "fulfillment:schemaRegistryUsername",
+    "fulfillment:schemaRegistryPassword": "fulfillment:schemaRegistryPassword",
+    "fulfillment:startOffset": "fulfillment:startOffset",
+
+    "fulfillment:apiEndpoint": "fulfillment:apiEndpoint",
+    "fulfillment:apiDocUrl": "fulfillment:apiDocUrl",
+    "fulfillment:authScheme": "fulfillment:authScheme",
+    "fulfillment:bearerToken": "fulfillment:bearerToken",
+    "fulfillment:apiKey": "fulfillment:apiKey",
+    "fulfillment:rateLimitRpm": "fulfillment:rateLimitRpm",
+
+    "fulfillment:cloudProvider": "fulfillment:cloudProvider",
+    "fulfillment:accessType": "fulfillment:accessType",
+    "fulfillment:bucket": "fulfillment:bucket",
+    "fulfillment:storagePrefix": "fulfillment:storagePrefix",
+    "fulfillment:presignedUrl": "fulfillment:presignedUrl",
+    "fulfillment:accessKeyId": "fulfillment:accessKeyId",
+    "fulfillment:secretAccessKey": "fulfillment:secretAccessKey",
+    "fulfillment:sessionToken": "fulfillment:sessionToken",
+    "fulfillment:sasToken": "fulfillment:sasToken",
+    "fulfillment:storageRegion": "fulfillment:storageRegion",
+    "fulfillment:fileFormat": "fulfillment:fileFormat",
+    "fulfillment:partitionPattern": "fulfillment:partitionPattern"
+  }
+}

--- a/specification/schema/DatasetFulfillment/v1.1/vocab.jsonld
+++ b/specification/schema/DatasetFulfillment/v1.1/vocab.jsonld
@@ -1,0 +1,313 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "schema": "https://schema.org/",
+    "fulfillment": "https://beckn.org/schema/dataset-fulfillment#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#"
+  },
+  "@graph": [
+    {
+      "@id": "fulfillment:DatasetFulfillment",
+      "@type": "rdfs:Class",
+      "rdfs:label": "DatasetFulfillment",
+      "rdfs:comment": "Access provisioning details for a fulfilled dataset order.",
+      "rdfs:subClassOf": { "@id": "schema:DataDownload" }
+    },
+    {
+      "@id": "fulfillment:accessMethod",
+      "@type": "rdf:Property",
+      "rdfs:label": "accessMethod",
+      "rdfs:comment": "How the dataset is accessed: DOWNLOAD, API, STREAM, MQTT, KAFKA, DATA_LAKE, DATA_ROOM, or SFTP."
+    },
+    {
+      "@id": "fulfillment:accessUrl",
+      "@type": "rdf:Property",
+      "rdfs:label": "accessUrl",
+      "rdfs:comment": "Signed or time-limited URL for accessing the dataset (DOWNLOAD only)."
+    },
+    {
+      "@id": "fulfillment:accessStart",
+      "@type": "rdf:Property",
+      "rdfs:label": "accessStart",
+      "rdfs:comment": "Start of the access window (ISO 8601 date-time)."
+    },
+    {
+      "@id": "fulfillment:accessEnd",
+      "@type": "rdf:Property",
+      "rdfs:label": "accessEnd",
+      "rdfs:comment": "End of the access window (ISO 8601 date-time). For streaming, use streamConnection.credentialExpiresAt."
+    },
+    {
+      "@id": "fulfillment:format",
+      "@type": "rdf:Property",
+      "rdfs:label": "format",
+      "rdfs:comment": "File or message format delivered (e.g. Parquet, CSV, JSON, Avro, NDJSON)."
+    },
+    {
+      "@id": "fulfillment:fileSizeBytes",
+      "@type": "rdf:Property",
+      "rdfs:label": "fileSizeBytes",
+      "rdfs:comment": "Approximate size of the delivered file in bytes (DOWNLOAD only)."
+    },
+    {
+      "@id": "fulfillment:maxDownloads",
+      "@type": "rdf:Property",
+      "rdfs:label": "maxDownloads",
+      "rdfs:comment": "Maximum number of times the dataset can be downloaded (DOWNLOAD only)."
+    },
+    {
+      "@id": "fulfillment:downloadsUsed",
+      "@type": "rdf:Property",
+      "rdfs:label": "downloadsUsed",
+      "rdfs:comment": "Number of downloads already used by the buyer (DOWNLOAD only)."
+    },
+    {
+      "@id": "fulfillment:supportEmail",
+      "@type": "rdf:Property",
+      "rdfs:label": "supportEmail",
+      "rdfs:comment": "Support email for issues related to dataset access."
+    },
+    {
+      "@id": "fulfillment:termsUrl",
+      "@type": "rdf:Property",
+      "rdfs:label": "termsUrl",
+      "rdfs:comment": "URL to the terms and conditions for dataset use."
+    },
+    {
+      "@id": "fulfillment:attributionText",
+      "@type": "rdf:Property",
+      "rdfs:label": "attributionText",
+      "rdfs:comment": "Required attribution text for the dataset."
+    },
+    {
+      "@id": "fulfillment:streamConnection",
+      "@type": "rdf:Property",
+      "rdfs:label": "streamConnection",
+      "rdfs:comment": "Stream connection credentials provisioned for the buyer after confirm. Required when accessMethod is MQTT, KAFKA, API, or DATA_LAKE. The @type field discriminates between MQTTConnection, KafkaConsumerCredentials, ApiCredential, and DataLakeCredential shapes."
+    },
+    {
+      "@id": "fulfillment:credentialExpiresAt",
+      "@type": "rdf:Property",
+      "rdfs:label": "credentialExpiresAt",
+      "rdfs:comment": "ISO 8601 date-time when the stream credentials expire. The buyer must call update before this timestamp to rotate credentials."
+    },
+    {
+      "@id": "fulfillment:brokerUri",
+      "@type": "rdf:Property",
+      "rdfs:label": "brokerUri",
+      "rdfs:comment": "MQTT broker URI (e.g. mqtts://iotcore.example.com:8883). Used in MQTTConnection."
+    },
+    {
+      "@id": "fulfillment:topic",
+      "@type": "rdf:Property",
+      "rdfs:label": "topic",
+      "rdfs:comment": "MQTT topic filter the buyer subscribes to (e.g. energy/meters/zone-a/#). Used in MQTTConnection."
+    },
+    {
+      "@id": "fulfillment:qos",
+      "@type": "rdf:Property",
+      "rdfs:label": "qos",
+      "rdfs:comment": "MQTT Quality of Service level (0, 1, or 2). Used in MQTTConnection."
+    },
+    {
+      "@id": "fulfillment:clientId",
+      "@type": "rdf:Property",
+      "rdfs:label": "clientId",
+      "rdfs:comment": "MQTT client ID provisioned for this buyer. Used in MQTTConnection."
+    },
+    {
+      "@id": "fulfillment:username",
+      "@type": "rdf:Property",
+      "rdfs:label": "username",
+      "rdfs:comment": "MQTT username (short-lived credential). Used in MQTTConnection."
+    },
+    {
+      "@id": "fulfillment:password",
+      "@type": "rdf:Property",
+      "rdfs:label": "password",
+      "rdfs:comment": "MQTT password or JWT token (short-lived). Used in MQTTConnection."
+    },
+    {
+      "@id": "fulfillment:tlsCaCert",
+      "@type": "rdf:Property",
+      "rdfs:label": "tlsCaCert",
+      "rdfs:comment": "PEM-encoded CA certificate for TLS verification (mqtts:// connections). Used in MQTTConnection."
+    },
+    {
+      "@id": "fulfillment:sessionExpiry",
+      "@type": "rdf:Property",
+      "rdfs:label": "sessionExpiry",
+      "rdfs:comment": "MQTT 5.0 Session Expiry Interval as ISO 8601 duration (e.g. PT24H). Used in MQTTConnection."
+    },
+    {
+      "@id": "fulfillment:bootstrapServers",
+      "@type": "rdf:Property",
+      "rdfs:label": "bootstrapServers",
+      "rdfs:comment": "Comma-separated Kafka bootstrap server list. Used in KafkaConsumerCredentials."
+    },
+    {
+      "@id": "fulfillment:topicName",
+      "@type": "rdf:Property",
+      "rdfs:label": "topicName",
+      "rdfs:comment": "Kafka topic to consume. Used in KafkaConsumerCredentials."
+    },
+    {
+      "@id": "fulfillment:consumerGroupId",
+      "@type": "rdf:Property",
+      "rdfs:label": "consumerGroupId",
+      "rdfs:comment": "Kafka consumer group ID provisioned for this buyer. Used in KafkaConsumerCredentials."
+    },
+    {
+      "@id": "fulfillment:saslMechanism",
+      "@type": "rdf:Property",
+      "rdfs:label": "saslMechanism",
+      "rdfs:comment": "SASL authentication mechanism (PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER). Used in KafkaConsumerCredentials."
+    },
+    {
+      "@id": "fulfillment:saslUsername",
+      "@type": "rdf:Property",
+      "rdfs:label": "saslUsername",
+      "rdfs:comment": "Kafka SASL username or API key (short-lived). Used in KafkaConsumerCredentials."
+    },
+    {
+      "@id": "fulfillment:saslPassword",
+      "@type": "rdf:Property",
+      "rdfs:label": "saslPassword",
+      "rdfs:comment": "Kafka SASL password or API secret (short-lived). Used in KafkaConsumerCredentials."
+    },
+    {
+      "@id": "fulfillment:schemaRegistryUrl",
+      "@type": "rdf:Property",
+      "rdfs:label": "schemaRegistryUrl",
+      "rdfs:comment": "Schema Registry URL for Avro or Protobuf deserialization. Used in KafkaConsumerCredentials."
+    },
+    {
+      "@id": "fulfillment:schemaRegistryUsername",
+      "@type": "rdf:Property",
+      "rdfs:label": "schemaRegistryUsername",
+      "rdfs:comment": "Schema Registry username. Used in KafkaConsumerCredentials."
+    },
+    {
+      "@id": "fulfillment:schemaRegistryPassword",
+      "@type": "rdf:Property",
+      "rdfs:label": "schemaRegistryPassword",
+      "rdfs:comment": "Schema Registry password. Used in KafkaConsumerCredentials."
+    },
+    {
+      "@id": "fulfillment:startOffset",
+      "@type": "rdf:Property",
+      "rdfs:label": "startOffset",
+      "rdfs:comment": "Where to begin consuming: latest (default) or earliest. Used in KafkaConsumerCredentials."
+    },
+    {
+      "@id": "fulfillment:apiEndpoint",
+      "@type": "rdf:Property",
+      "rdfs:label": "apiEndpoint",
+      "rdfs:comment": "Base URL of the REST API. Used in ApiCredential."
+    },
+    {
+      "@id": "fulfillment:apiDocUrl",
+      "@type": "rdf:Property",
+      "rdfs:label": "apiDocUrl",
+      "rdfs:comment": "URL to the OpenAPI / Swagger specification. Buyers use this to auto-generate clients or explore endpoints. Used in ApiCredential."
+    },
+    {
+      "@id": "fulfillment:authScheme",
+      "@type": "rdf:Property",
+      "rdfs:label": "authScheme",
+      "rdfs:comment": "Authentication scheme for the API: BEARER, API_KEY, BASIC, or OAUTH2_CLIENT_CREDENTIALS. Used in ApiCredential."
+    },
+    {
+      "@id": "fulfillment:bearerToken",
+      "@type": "rdf:Property",
+      "rdfs:label": "bearerToken",
+      "rdfs:comment": "Short-lived bearer token (JWT). Rotate via update before credentialExpiresAt. Used in ApiCredential."
+    },
+    {
+      "@id": "fulfillment:apiKey",
+      "@type": "rdf:Property",
+      "rdfs:label": "apiKey",
+      "rdfs:comment": "Short-lived API key. Rotate via update before credentialExpiresAt. Used in ApiCredential."
+    },
+    {
+      "@id": "fulfillment:rateLimitRpm",
+      "@type": "rdf:Property",
+      "rdfs:label": "rateLimitRpm",
+      "rdfs:comment": "Requests per minute allowed under this contract. Used in ApiCredential."
+    },
+    {
+      "@id": "fulfillment:cloudProvider",
+      "@type": "rdf:Property",
+      "rdfs:label": "cloudProvider",
+      "rdfs:comment": "Cloud object storage provider: AWS_S3, GCS, or AZURE_ADLS. Used in DataLakeCredential."
+    },
+    {
+      "@id": "fulfillment:accessType",
+      "@type": "rdf:Property",
+      "rdfs:label": "accessType",
+      "rdfs:comment": "Credential type for cloud storage: PRESIGNED_URL, STS_CREDENTIALS, or SAS_TOKEN. Used in DataLakeCredential."
+    },
+    {
+      "@id": "fulfillment:bucket",
+      "@type": "rdf:Property",
+      "rdfs:label": "bucket",
+      "rdfs:comment": "S3 or GCS bucket name. Used in DataLakeCredential."
+    },
+    {
+      "@id": "fulfillment:storagePrefix",
+      "@type": "rdf:Property",
+      "rdfs:label": "storagePrefix",
+      "rdfs:comment": "Object key prefix scoped to this buyer's data partition. Used in DataLakeCredential."
+    },
+    {
+      "@id": "fulfillment:presignedUrl",
+      "@type": "rdf:Property",
+      "rdfs:label": "presignedUrl",
+      "rdfs:comment": "Pre-signed GET URL (PRESIGNED_URL access type only). Used in DataLakeCredential."
+    },
+    {
+      "@id": "fulfillment:accessKeyId",
+      "@type": "rdf:Property",
+      "rdfs:label": "accessKeyId",
+      "rdfs:comment": "AWS temporary access key ID (STS_CREDENTIALS only). Used in DataLakeCredential."
+    },
+    {
+      "@id": "fulfillment:secretAccessKey",
+      "@type": "rdf:Property",
+      "rdfs:label": "secretAccessKey",
+      "rdfs:comment": "AWS temporary secret access key (STS_CREDENTIALS only). Used in DataLakeCredential."
+    },
+    {
+      "@id": "fulfillment:sessionToken",
+      "@type": "rdf:Property",
+      "rdfs:label": "sessionToken",
+      "rdfs:comment": "AWS STS session token (STS_CREDENTIALS only). Used in DataLakeCredential."
+    },
+    {
+      "@id": "fulfillment:sasToken",
+      "@type": "rdf:Property",
+      "rdfs:label": "sasToken",
+      "rdfs:comment": "Azure SAS token appended to the blob or container URL (SAS_TOKEN only). Used in DataLakeCredential."
+    },
+    {
+      "@id": "fulfillment:storageRegion",
+      "@type": "rdf:Property",
+      "rdfs:label": "storageRegion",
+      "rdfs:comment": "Cloud region where the storage bucket is hosted. Used in DataLakeCredential."
+    },
+    {
+      "@id": "fulfillment:fileFormat",
+      "@type": "rdf:Property",
+      "rdfs:label": "fileFormat",
+      "rdfs:comment": "Format of files in the storage path (e.g. NDJSON, Parquet, CSV). Used in DataLakeCredential."
+    },
+    {
+      "@id": "fulfillment:partitionPattern",
+      "@type": "rdf:Property",
+      "rdfs:label": "partitionPattern",
+      "rdfs:comment": "Partition path pattern for live-append datasets (e.g. year={yyyy}/month={MM}/day={dd}/). Used in DataLakeCredential."
+    }
+  ]
+}

--- a/specification/schema/DatasetItem/v1.1/README.md
+++ b/specification/schema/DatasetItem/v1.1/README.md
@@ -1,0 +1,80 @@
+# DatasetItem — v1.1
+
+Extends [v1](../v1/attributes.yaml) with streaming transport access methods and catalog-time stream metadata. Fully backward-compatible — all v1 fields and enum values are preserved unchanged.
+
+## What's new in v1.1
+
+### Extended `dataset:accessMethod` enum
+
+Four new values alongside the existing `INLINE`, `DOWNLOAD`, `DATA_ENCLAVE`, `OFF_CHANNEL`:
+
+| Value | Transport | Credentials delivered via |
+|---|---|---|
+| `MQTT` | MQTT 5.0 broker subscription | `DatasetFulfillment/v1.1` `streamConnection` in `on_confirm` |
+| `KAFKA` | Apache Kafka consumer | `DatasetFulfillment/v1.1` `streamConnection` in `on_confirm` |
+| `API` | REST API with API key or bearer token | `DatasetFulfillment/v1.1` `streamConnection` in `on_confirm` |
+| `DATA_LAKE` | Cloud object storage — S3 / GCS / ADLS | `DatasetFulfillment/v1.1` `streamConnection` in `on_confirm` |
+
+### New `dataset:streamMeta` field
+
+A catalog-time sub-object that describes the stream's topology **without exposing credentials**. Buyers use this to understand what they are purchasing and to configure deserializers before the stream starts.
+
+```json
+"dataset:streamMeta": {
+  "dataset:streamProtocol": "MQTT",
+  "dataset:messageFormat": "JSON",
+  "dataset:updateFrequency": "PT15M",
+  "dataset:messageSchemaUrl": "https://example.com/schemas/meter-reading-v2.json"
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `dataset:streamProtocol` | `MQTT` \| `KAFKA` \| `API` \| `DATA_LAKE` | Informational mirror of `accessMethod` |
+| `dataset:messageFormat` | string | Message encoding: `JSON`, `NDJSON`, `Avro`, `Protobuf`, `Parquet`, `CSV`, … |
+| `dataset:updateFrequency` | ISO 8601 duration or `REAL_TIME` | How often new data arrives, e.g. `PT15M`, `PT1S`, `REAL_TIME` |
+| `dataset:messageSchemaUrl` | URI | URL to the message schema (JSON Schema / Avro / Protobuf / OpenAPI) |
+
+## Beckn handshake flow for streaming transports
+
+```
+discover      BAP filters by dataset:accessMethod in [MQTT, KAFKA, API, DATA_LAKE]
+on_discover   BPP returns items with dataset:streamMeta — no credentials yet
+confirm       BAP confirms and pays
+on_confirm    BPP provisions credentials and delivers them in
+              performance[].performanceAttributes as DatasetFulfillment/v1.1
+              with fulfillment:streamConnection
+update        BAP rotates credentials before fulfillment:credentialExpiresAt
+on_update     BPP issues fresh fulfillment:streamConnection
+```
+
+Credentials never appear in the catalog (`on_discover`). They are provisioned on-demand after `confirm` and delivered in `on_confirm`, scoped to the specific buyer and contract.
+
+## Catalog example
+
+```json
+{
+  "@context": "https://raw.githubusercontent.com/beckn/DDM/main/specification/schema/DatasetItem/v1.1/context.jsonld",
+  "@type": "DatasetItem",
+  "schema:identifier": "stream-ami-mqtt-blr-zone-a",
+  "schema:name": "AMI Smart Meter Stream — Bengaluru Zone A",
+  "schema:temporalCoverage": "2026-05-07/..",
+  "dataset:refreshType": "REAL_TIME",
+  "dataset:accessMethod": "MQTT",
+  "dataset:sensitivityLevel": "CONFIDENTIAL",
+  "dataset:streamMeta": {
+    "dataset:streamProtocol": "MQTT",
+    "dataset:messageFormat": "JSON",
+    "dataset:updateFrequency": "PT15M",
+    "dataset:messageSchemaUrl": "https://raw.githubusercontent.com/beckn/DEG/main/specification/schema/BecknTimeSeries/v1.0/attributes.yaml"
+  }
+}
+```
+
+See [`/example/v1.1/streaming/`](../../../../example/v1.1/streaming/) for full end-to-end flow examples covering MQTT, Kafka, REST API, and Data Lake.
+
+## Context URL
+
+```
+https://raw.githubusercontent.com/beckn/DDM/main/specification/schema/DatasetItem/v1.1/context.jsonld
+```

--- a/specification/schema/DatasetItem/v1.1/attributes.yaml
+++ b/specification/schema/DatasetItem/v1.1/attributes.yaml
@@ -1,0 +1,200 @@
+openapi: 3.1.0
+info:
+  title: DatasetItem
+  version: 1.1.0
+  description: >
+    Attributes for dataset products exposed via beckn:itemAttributes.
+    v1.1 adds streaming transport access methods (MQTT, KAFKA, API, DATA_LAKE)
+    and the dataset:streamMeta sub-object for catalog-time stream topology
+    metadata. Fully backward-compatible with v1.0.
+paths: {}
+components:
+  schemas:
+    DatasetItem:
+      type: object
+      description: Dataset metadata aligned with schema.org Dataset plus Beckn dataset extensions.
+      additionalProperties: true
+      required:
+        - "schema:identifier"
+        - "schema:name"
+        - "schema:temporalCoverage"
+      properties:
+        "@context":
+          oneOf:
+            - type: string
+              format: uri
+            - type: array
+              items:
+                type: string
+                format: uri
+        "@type":
+          type: string
+          enum: ["DatasetItem"]
+        "schema:identifier":
+          type: string
+        "schema:name":
+          type: string
+        "schema:description":
+          type: string
+        "schema:temporalCoverage":
+          type: string
+        "schema:spatialCoverage":
+          oneOf:
+            - type: string
+            - type: object
+        "schema:license":
+          oneOf:
+            - type: string
+            - type: object
+        "schema:distribution":
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        "schema:variableMeasured":
+          type: array
+          items:
+            oneOf:
+              - type: string
+              - type: object
+        "schema:measurementTechnique":
+          oneOf:
+            - type: string
+            - type: object
+        "schema:usageInfo":
+          oneOf:
+            - type: string
+            - type: object
+        "schema:conditionsOfAccess":
+          oneOf:
+            - type: string
+            - type: object
+        "schema:temporalResolution":
+          oneOf:
+            - type: string
+            - type: object
+        "schema:spatialResolution":
+          oneOf:
+            - type: string
+            - type: object
+        "schema:creator":
+          oneOf:
+            - type: string
+            - type: object
+        "schema:isBasedOn":
+          oneOf:
+            - type: string
+            - type: array
+        "dataset:refreshType":
+          type: string
+        "dataset:refreshFrequency":
+          type: string
+        "dataset:granularity":
+          type: string
+        "dataset:rowCountEstimate":
+          type: integer
+        "dataset:columnCount":
+          type: integer
+        "dataset:sensitivityLevel":
+          type: string
+        "dataset:verticalRange":
+          oneOf:
+            - type: string
+            - type: object
+        "dataset:dataType":
+          type: string
+        "dataset:rawUpdateFrequency":
+          type: string
+        "dataset:latestRawDataAt":
+          type: string
+          format: date-time
+        "dataset:accessMethod":
+          type: string
+          description: >
+            How the dataset is delivered to the consumer.
+            INLINE — data embedded in the beckn message via dataPayload.
+            DOWNLOAD — consumer fetches from a URL in schema:distribution.
+            DATA_ENCLAVE — consumer accesses data within a secure enclave environment.
+            OFF_CHANNEL — delivery arranged outside the beckn network.
+            MQTT — real-time push over MQTT 5.0; credentials delivered in DatasetFulfillment after confirm.
+            KAFKA — high-throughput event stream via Apache Kafka; credentials delivered in DatasetFulfillment after confirm.
+            API — REST API access with API key or bearer token; endpoint and doc URL delivered in DatasetFulfillment after confirm.
+            DATA_LAKE — bulk or live delivery to cloud object storage (S3/GCS/ADLS); credentials delivered in DatasetFulfillment after confirm.
+          enum:
+            - INLINE
+            - DOWNLOAD
+            - DATA_ENCLAVE
+            - OFF_CHANNEL
+            - MQTT
+            - KAFKA
+            - API
+            - DATA_LAKE
+        "dataset:streamMeta":
+          type: object
+          description: >
+            Catalog-time metadata describing the stream topology. Present when
+            dataset:accessMethod is MQTT, KAFKA, API, or DATA_LAKE. Conveys
+            what the stream looks like (format, frequency, message schema) without
+            exposing credentials. Credentials are provisioned in DatasetFulfillment
+            after the buyer confirms the order.
+          additionalProperties: true
+          properties:
+            "dataset:streamProtocol":
+              type: string
+              description: Transport protocol — informational mirror of accessMethod.
+              enum: [MQTT, KAFKA, API, DATA_LAKE]
+            "dataset:messageFormat":
+              type: string
+              description: >
+                Encoding format for stream messages or delivered files.
+                Examples: JSON, NDJSON, Avro, Protobuf, Parquet, CSV.
+            "dataset:updateFrequency":
+              type: string
+              description: >
+                How often new data arrives. ISO 8601 duration (e.g. PT15M)
+                or the literal REAL_TIME for sub-second streams.
+            "dataset:messageSchemaUrl":
+              type: string
+              format: uri
+              description: >
+                URL to the message or file schema (JSON Schema, Avro schema,
+                Protobuf descriptor, or OpenAPI spec). Consumers use this to
+                configure deserializers before the stream starts.
+        "dataset:dataPayload":
+          description: >
+            Optional inline data payload. When present, carries the actual dataset
+            content within the beckn message. The @context URI must resolve to a
+            valid schema that describes the payload structure. Used when
+            dataset:accessMethod is INLINE.
+          type: object
+          required:
+            - "@context"
+            - "@type"
+          additionalProperties: true
+          properties:
+            "@context":
+              description: JSON-LD context URI resolving to the payload's schema.
+              oneOf:
+                - type: string
+                  format: uri
+                - type: array
+                  items:
+                    type: string
+                    format: uri
+            "@type":
+              description: The type of data payload (e.g., MeterData, BillingSummary, UtilityCustomerCredential).
+              type: string
+        "dataset:qualityFlags":
+          type: object
+          additionalProperties: true
+          properties:
+            "dataset:gapFilledPercent":
+              type: number
+            "dataset:outlierRemovedPercent":
+              type: number
+            "dataset:latencyMinutes":
+              type: integer
+            "dataset:uptime99DayPercent":
+              type: number
+            "dataset:validationMethod":
+              type: string

--- a/specification/schema/DatasetItem/v1.1/context.jsonld
+++ b/specification/schema/DatasetItem/v1.1/context.jsonld
@@ -1,0 +1,40 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "schema": "https://schema.org/",
+    "dataset": "./vocab.jsonld#",
+
+    "DatasetItem": "dataset:DatasetItem",
+
+    "refreshType": "dataset:refreshType",
+    "refreshFrequency": "dataset:refreshFrequency",
+    "granularity": "dataset:granularity",
+    "rowCountEstimate": "dataset:rowCountEstimate",
+    "columnCount": "dataset:columnCount",
+    "sensitivityLevel": "dataset:sensitivityLevel",
+
+    "qualityFlags": "dataset:qualityFlags",
+    "gapFilledPercent": "dataset:gapFilledPercent",
+    "outlierRemovedPercent": "dataset:outlierRemovedPercent",
+    "latencyMinutes": "dataset:latencyMinutes",
+    "uptime99DayPercent": "dataset:uptime99DayPercent",
+    "validationMethod": "dataset:validationMethod",
+
+    "accessMethod": "dataset:accessMethod",
+    "dataPayload": {
+      "@id": "dataset:dataPayload",
+      "@type": "@id"
+    },
+
+    "streamMeta": "dataset:streamMeta",
+    "streamProtocol": "dataset:streamProtocol",
+    "messageFormat": "dataset:messageFormat",
+    "updateFrequency": "dataset:updateFrequency",
+    "messageSchemaUrl": "dataset:messageSchemaUrl",
+
+    "verticalRange": "dataset:verticalRange",
+    "dataType": "dataset:dataType",
+    "rawUpdateFrequency": "dataset:rawUpdateFrequency",
+    "latestRawDataAt": "dataset:latestRawDataAt"
+  }
+}

--- a/specification/schema/DatasetItem/v1.1/vocab.jsonld
+++ b/specification/schema/DatasetItem/v1.1/vocab.jsonld
@@ -1,0 +1,159 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "dataset": "https://beckn.org/schema/dataset#",
+    "schema": "https://schema.org/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#"
+  },
+  "@graph": [
+    {
+      "@id": "dataset:DatasetItem",
+      "@type": "rdfs:Class",
+      "rdfs:label": "DatasetItem",
+      "rdfs:comment": "A dataset product in a Beckn catalog, extending schema.org Dataset.",
+      "rdfs:subClassOf": {
+        "@id": "schema:Dataset"
+      }
+    },
+    {
+      "@id": "dataset:refreshType",
+      "@type": "rdf:Property",
+      "rdfs:label": "refreshType",
+      "rdfs:comment": "Refresh model for the dataset (STATIC, RECURRING, REAL_TIME)."
+    },
+    {
+      "@id": "dataset:refreshFrequency",
+      "@type": "rdf:Property",
+      "rdfs:label": "refreshFrequency",
+      "rdfs:comment": "Refresh frequency when the dataset is recurring or real-time."
+    },
+    {
+      "@id": "dataset:granularity",
+      "@type": "rdf:Property",
+      "rdfs:label": "granularity",
+      "rdfs:comment": "Observation unit granularity of the dataset (e.g. GRID_DAILY, STATION_HOURLY)."
+    },
+    {
+      "@id": "dataset:rowCountEstimate",
+      "@type": "rdf:Property",
+      "rdfs:label": "rowCountEstimate",
+      "rdfs:comment": "Approximate number of rows in the dataset."
+    },
+    {
+      "@id": "dataset:columnCount",
+      "@type": "rdf:Property",
+      "rdfs:label": "columnCount",
+      "rdfs:comment": "Number of columns in the dataset."
+    },
+    {
+      "@id": "dataset:sensitivityLevel",
+      "@type": "rdf:Property",
+      "rdfs:label": "sensitivityLevel",
+      "rdfs:comment": "Sensitivity classification for the dataset (PUBLIC, INTERNAL, CONFIDENTIAL, etc.)."
+    },
+    {
+      "@id": "dataset:qualityFlags",
+      "@type": "rdf:Property",
+      "rdfs:label": "qualityFlags",
+      "rdfs:comment": "Container for data quality metrics for the dataset."
+    },
+    {
+      "@id": "dataset:gapFilledPercent",
+      "@type": "rdf:Property",
+      "rdfs:label": "gapFilledPercent",
+      "rdfs:comment": "Percentage of records gap-filled by imputation."
+    },
+    {
+      "@id": "dataset:outlierRemovedPercent",
+      "@type": "rdf:Property",
+      "rdfs:label": "outlierRemovedPercent",
+      "rdfs:comment": "Percentage of records removed as outliers."
+    },
+    {
+      "@id": "dataset:latencyMinutes",
+      "@type": "rdf:Property",
+      "rdfs:label": "latencyMinutes",
+      "rdfs:comment": "Typical latency in minutes between observation and availability."
+    },
+    {
+      "@id": "dataset:uptime99DayPercent",
+      "@type": "rdf:Property",
+      "rdfs:label": "uptime99DayPercent",
+      "rdfs:comment": "Feed uptime percentage over the last 99 days."
+    },
+    {
+      "@id": "dataset:validationMethod",
+      "@type": "rdf:Property",
+      "rdfs:label": "validationMethod",
+      "rdfs:comment": "Standard or algorithm used for dataset validation."
+    },
+    {
+      "@id": "dataset:accessMethod",
+      "@type": "rdf:Property",
+      "rdfs:label": "accessMethod",
+      "rdfs:comment": "How the dataset is delivered: INLINE, DOWNLOAD, DATA_ENCLAVE, OFF_CHANNEL, MQTT, KAFKA, API, or DATA_LAKE. For streaming methods, credentials are provisioned in DatasetFulfillment after confirm."
+    },
+    {
+      "@id": "dataset:dataPayload",
+      "@type": "rdf:Property",
+      "rdfs:label": "dataPayload",
+      "rdfs:comment": "Optional inline data payload carrying actual dataset content within the beckn message. A self-describing JSON-LD object whose @context resolves to the payload schema."
+    },
+    {
+      "@id": "dataset:streamMeta",
+      "@type": "rdf:Property",
+      "rdfs:label": "streamMeta",
+      "rdfs:comment": "Catalog-time stream topology metadata (format, frequency, message schema URL). Present when accessMethod is MQTT, KAFKA, API, or DATA_LAKE. Does not contain credentials."
+    },
+    {
+      "@id": "dataset:streamProtocol",
+      "@type": "rdf:Property",
+      "rdfs:label": "streamProtocol",
+      "rdfs:comment": "Transport protocol for the stream (MQTT, KAFKA, API, DATA_LAKE). Informational mirror of accessMethod."
+    },
+    {
+      "@id": "dataset:messageFormat",
+      "@type": "rdf:Property",
+      "rdfs:label": "messageFormat",
+      "rdfs:comment": "Encoding format for stream messages or delivered files (e.g. JSON, NDJSON, Avro, Protobuf, Parquet, CSV)."
+    },
+    {
+      "@id": "dataset:updateFrequency",
+      "@type": "rdf:Property",
+      "rdfs:label": "updateFrequency",
+      "rdfs:comment": "How often new data arrives: ISO 8601 duration (e.g. PT15M) or REAL_TIME for sub-second streams."
+    },
+    {
+      "@id": "dataset:messageSchemaUrl",
+      "@type": "rdf:Property",
+      "rdfs:label": "messageSchemaUrl",
+      "rdfs:comment": "URL to the message or file schema (JSON Schema, Avro schema, Protobuf descriptor, or OpenAPI spec). Consumers use this to configure deserializers."
+    },
+    {
+      "@id": "dataset:verticalRange",
+      "@type": "rdf:Property",
+      "rdfs:label": "verticalRange",
+      "rdfs:comment": "Vertical extent of the dataset (e.g. surface, 0–2km AGL)."
+    },
+    {
+      "@id": "dataset:dataType",
+      "@type": "rdf:Property",
+      "rdfs:label": "dataType",
+      "rdfs:comment": "Type or representation of the data (e.g. GriddedProbabilityField, TimeSeries)."
+    },
+    {
+      "@id": "dataset:rawUpdateFrequency",
+      "@type": "rdf:Property",
+      "rdfs:label": "rawUpdateFrequency",
+      "rdfs:comment": "Frequency at which the underlying raw dataset is updated."
+    },
+    {
+      "@id": "dataset:latestRawDataAt",
+      "@type": "rdf:Property",
+      "rdfs:label": "latestRawDataAt",
+      "rdfs:comment": "Timestamp of the latest raw data available that feeds this dataset."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Extends `DatasetItem` and `DatasetFulfillment` schemas to support real-time streaming transports. This enables data providers (BPPs) to negotiate and deliver MQTT, Kafka, REST API, and cloud object storage access through the standard beckn handshake — with credentials delivered in `on_confirm.performance[].performanceAttributes`.

### Motivation

The current DDM schema supports `INLINE` and `DOWNLOAD` delivery well, but real-world energy and grid data providers primarily distribute data via streaming brokers (MQTT for IoT meter data, Kafka for grid events), REST APIs (solar forecasts, grid topology), and cloud data lakes (bulk/live-append historical data). This PR adds the schema primitives needed to negotiate and provision those transports without leaving the beckn protocol layer.

### DatasetItem changes (`specification/schema/DatasetItem/v1/`)

- **`dataset:accessMethod` enum** — adds `MQTT`, `KAFKA`, `API`, `DATA_LAKE` alongside the existing `INLINE`, `DOWNLOAD`, `DATA_ENCLAVE`, `OFF_CHANNEL`
- **`dataset:streamMeta`** (new) — catalog-time stream topology metadata:
  - `dataset:streamProtocol` — informational mirror of accessMethod
  - `dataset:messageFormat` — JSON, NDJSON, Avro, Protobuf, Parquet, CSV, …
  - `dataset:updateFrequency` — ISO 8601 duration or `REAL_TIME`
  - `dataset:messageSchemaUrl` — URL to JSON Schema / Avro schema / OpenAPI spec; consumers configure deserializers from this before the stream starts

All three files updated: `attributes.yaml`, `context.jsonld`, `vocab.jsonld`.

### DatasetFulfillment changes (`specification/schema/DatasetFulfillment/v1/`)

- **`required` relaxed** — only `fulfillment:accessMethod` is required; `accessUrl`, `accessStart`, `accessEnd` remain defined but are optional (they apply to `DOWNLOAD`; streaming methods use `credentialExpiresAt` instead)
- **`fulfillment:accessMethod` enum aligned** — now includes `MQTT`, `KAFKA`, `DATA_LAKE` alongside existing `DOWNLOAD`, `API`, `STREAM`, `DATA_ROOM`, `SFTP`
- **`fulfillment:streamConnection`** (new) — credential delivery object with `@type` discriminator:

| `@type` | Transport | Key fields |
|---|---|---|
| `MQTTConnection` | MQTT 5.0 | `brokerUri`, `topic`, `qos`, `clientId`, `username`, `password` (JWT), `tlsCaCert`, `sessionExpiry` |
| `KafkaConsumerCredentials` | Apache Kafka | `bootstrapServers`, `topicName`, `consumerGroupId`, `saslMechanism`, `saslUsername/Password`, `schemaRegistryUrl/Username/Password`, `startOffset` |
| `ApiCredential` | REST API | `apiEndpoint`, `apiDocUrl`, `authScheme`, `bearerToken` or `apiKey`, `rateLimitRpm` |
| `DataLakeCredential` | S3 / GCS / ADLS | `cloudProvider`, `accessType` (`PRESIGNED_URL` / `STS_CREDENTIALS` / `SAS_TOKEN`), `bucket`, `storagePrefix`, `presignedUrl` or `accessKeyId/secretAccessKey/sessionToken` or `sasToken`, `fileFormat`, `partitionPattern` |

- **`fulfillment:credentialExpiresAt`** — across all streaming types; buyers must call `update` before this timestamp to rotate credentials and maintain stream access

All three files updated: `attributes.yaml`, `context.jsonld`, `vocab.jsonld`.

### Handshake flow (minimal)

```
discover  →  BAP searches for accessMethod in [MQTT, KAFKA, API, DATA_LAKE]
on_discover  →  BPP returns catalog items with dataset:streamMeta (no credentials)
confirm  →  BAP confirms and pays
on_confirm  →  BPP provisions transport credentials and delivers them in
               performance[].performanceAttributes as DatasetFulfillment
               with fulfillment:streamConnection
update  →  BAP rotates credentials before credentialExpiresAt
on_update  →  BPP issues fresh fulfillment:streamConnection
```

### Backward compatibility

- All additions are new optional fields; no existing required fields removed
- Existing `DOWNLOAD` flow is unchanged
- `accessUrl`, `accessStart`, `accessEnd` still present; only removed from `required`

## Test plan

- [ ] Validate `DatasetItem/v1/attributes.yaml` and `DatasetFulfillment/v1/attributes.yaml` with an OpenAPI 3.1.0 linter
- [ ] Confirm `context.jsonld` terms resolve correctly against the updated `vocab.jsonld`
- [ ] Review `streamConnection` field names for consistency with existing `fulfillment:` prefix convention
- [ ] Confirm `credentialExpiresAt` guidance is sufficient for implementers

🤖 Generated with [Claude Code](https://claude.com/claude-code)